### PR TITLE
Fix content sanitization logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ allure-combine ./some/path/to/allure/generated/folder --remove-temp-files
 allure-combine ./some/path/to/allure/generated/folder --ignore-utf8-errors
 ```
 
+6) If the text content of generated HTML presents formatting issues, try this option:
+```bash
+allure-combine ./some/path/to/allure/generated/folder --disable-tags-escaping
+```
 
 ## Import and use in python code
 
@@ -118,12 +122,18 @@ combine_allure(
     ignore_utf8_errors=True
 )
 
+# 6) If the text content of generated HTML presents formatting issues, try this option:
+combine_allure(
+    "./some/path/to/allure/generated/folder",
+    disable_tags_escaping=True
+)
+
 
 ```
 
 ## Integration tests
 
-The repository contains Docker-based integration tests in `integration_tests/` that validate `allure-combine` CLI flows (including `--dest`, `--auto-create-folders`, `--remove-temp-files`, and `--ignore-utf8-errors`).
+The repository contains Docker-based integration tests in `integration_tests/` that validate `allure-combine` CLI flows (including `--dest`, `--auto-create-folders`, `--remove-temp-files`, `--ignore-utf8-errors`, and `--disable-tags-escaping`).
 
 Run full integration flow (requires Docker): build image, run tests, generate `complete.html` for each CLI variant, and validate every generated HTML in headless Chromium via Playwright.
 

--- a/allure_combine/combine.py
+++ b/allure_combine/combine.py
@@ -28,7 +28,7 @@ sep = os.sep
 re_sep = os.sep if os.sep == "/" else r"\\"
 
 
-def combine_allure(folder, dest_folder=None, remove_temp_files=False, auto_create_folders=False, ignore_utf8_errors=False):
+def combine_allure(folder, dest_folder=None, remove_temp_files=False, auto_create_folders=False, ignore_utf8_errors=False, disable_tags_escaping=False):
     """
     Read all files,
     create server.js,
@@ -199,7 +199,12 @@ def combine_allure(folder, dest_folder=None, remove_temp_files=False, auto_creat
                 f.write(f""" "{url}": "{content}", \n""")
             else:
                 content = d['content'].replace("\\", "\\\\").replace('"', '\\"')\
-                    .replace("\n", "\\n").replace("<", "&lt;").replace(">", "&gt;")
+                    .replace("\n", "\\n")
+                
+                if not disable_tags_escaping:
+                    content = content.replace("<", "&lt;").replace(">", "&gt;")
+                else:
+                    content = content.replace("<", "\\u003c").replace(">", "\\u003e")
 
                 f.write(f""" "{url}": "{content}", \n""")
         f.write("};\n")
@@ -305,9 +310,12 @@ def main():
                         help="Whether auto create dest folders or not when folder does not exist. Default is false.")
     parser.add_argument("--ignore-utf8-errors", action="store_true",
                         help="If test files does contain some broken unicode, decode errors would be ignored")
+    parser.add_argument("--disable-tags-escaping", action="store_true",
+                        help="Disable escaping of tag characters '<' and '>'. Use this if the text content of "
+                             "generated HTML presents formatting issues. Default is false.")
     args = parser.parse_args()
 
-    combine_allure(args.folder.rstrip(sep), args.dest, args.remove_temp_files, args.auto_create_folders, args.ignore_utf8_errors)
+    combine_allure(args.folder.rstrip(sep), args.dest, args.remove_temp_files, args.auto_create_folders, args.ignore_utf8_errors, args.disable_tags_escaping)
 
 
 if __name__ == '__main__':

--- a/integration_tests/dummy_tests/test_dummy.py
+++ b/integration_tests/dummy_tests/test_dummy.py
@@ -115,3 +115,34 @@ def test_cli_ignore_utf8_errors(generated_report, tmp_path):
     assert cmd_with_flag.returncode == 0, cmd_with_flag.stdout + cmd_with_flag.stderr
     assert "Error on reading file" not in (cmd_with_flag.stdout + cmd_with_flag.stderr)
     assert (source_with_flag / "complete.html").exists()
+
+
+def test_cli_disable_tags_escaping(generated_report, tmp_path):
+    source_default = _copy_report(generated_report, tmp_path / "default")
+    source_disabled = _copy_report(generated_report, tmp_path / "disabled")
+
+    # Create a file with HTML tags
+    html_content = "<script>alert('xss')</script>"
+    (source_default / "data" / "test.html").parent.mkdir(parents=True, exist_ok=True)
+    (source_default / "data" / "test.txt").write_text(html_content, encoding="utf-8")
+    
+    (source_disabled / "data" / "test.html").parent.mkdir(parents=True, exist_ok=True)
+    (source_disabled / "data" / "test.txt").write_text(html_content, encoding="utf-8")
+
+    # Run without flag (default behavior: escaping enabled)
+    cmd_default = _run(["allure-combine", str(source_default)])
+    assert cmd_default.returncode == 0, cmd_default.stdout + cmd_default.stderr
+    
+    content_default = (source_default / "complete.html").read_text(encoding="utf-8")
+    # Should be escaped
+    assert "&lt;script&gt;alert('xss')&lt;/script&gt;" in content_default
+    assert "<script>alert('xss')</script>" not in content_default
+
+    # Run with flag (escaping disabled)
+    cmd_disabled = _run(["allure-combine", str(source_disabled), "--disable-tags-escaping"])
+    assert cmd_disabled.returncode == 0, cmd_disabled.stdout + cmd_disabled.stderr
+    
+    content_disabled = (source_disabled / "complete.html").read_text(encoding="utf-8")
+    # Should NOT be escaped
+    assert r"\u003cscript\u003ealert('xss')\u003c/script\u003e" in content_disabled
+    assert "&lt;script&gt;alert('xss')&lt;/script&gt;" not in content_disabled

--- a/integration_tests/dummy_tests/test_security.py
+++ b/integration_tests/dummy_tests/test_security.py
@@ -1,0 +1,89 @@
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+def _run(cmd):
+    return subprocess.run(cmd, text=True, capture_output=True)
+
+@pytest.fixture
+def minimal_allure_report(tmp_path):
+    report_dir = tmp_path / "report"
+    report_dir.mkdir()
+    
+    (report_dir / "index.html").write_text(
+        '<html><head><script src="app.js"></script><link rel="stylesheet" href="styles.css"></head><body></body></html>',
+        encoding="utf-8"
+    )
+    (report_dir / "app.js").write_text('console.log("app");', encoding="utf-8")
+    (report_dir / "styles.css").write_text('body { color: red; }', encoding="utf-8")
+    
+    data_dir = report_dir / "data"
+    data_dir.mkdir()
+    
+    return report_dir
+
+def test_disable_tags_escaping_prevents_xss(minimal_allure_report, tmp_path):
+    """
+    Test that even when disable_tags_escaping is True, </script> tags in content
+    are escaped (as unicode escapes) to prevent breaking the parent script tag.
+    """
+    
+    # Create a file that triggers the issue
+    evil_content = 'Some content with </script> tag inside.'
+    (minimal_allure_report / "data" / "evil.txt").write_text(evil_content, encoding="utf-8")
+    
+    # Run allure-combine with --disable-tags-escaping
+    cmd = _run([sys.executable, "-m", "allure_combine.combine", str(minimal_allure_report), "--disable-tags-escaping"])
+    
+    assert cmd.returncode == 0, cmd.stdout + cmd.stderr
+    
+    complete_html = minimal_allure_report / "complete.html"
+    assert complete_html.exists()
+    
+    content = complete_html.read_text(encoding="utf-8")
+    
+    # We expect the literal </script> to NOT be present in the JS string definition
+    # because it should be escaped as \u003c/script\u003e
+    snippet_unescaped = '"data/evil.txt": "Some content with </script> tag inside."'
+    snippet_escaped = r'"data/evil.txt": "Some content with \u003c/script\u003e tag inside."'
+    
+    assert snippet_unescaped not in content, "Found unescaped </script> tag in the output!"
+    assert snippet_escaped in content, "Did not find expected escaped snippet."
+
+def test_disable_tags_escaping_preserves_html_semantics(minimal_allure_report):
+    """
+    Test that disable_tags_escaping=True preserves < and > as unicode escapes
+    which evaluate to correct characters in JS, effectively disabling HTML entity escaping.
+    """
+    
+    html_content = "<div><b>Bold</b></div>"
+    (minimal_allure_report / "data" / "content.txt").write_text(html_content, encoding="utf-8")
+    
+    cmd = _run([sys.executable, "-m", "allure_combine.combine", str(minimal_allure_report), "--disable-tags-escaping"])
+    assert cmd.returncode == 0
+    
+    content = (minimal_allure_report / "complete.html").read_text(encoding="utf-8")
+    
+    # Should use unicode escapes
+    expected = r'"data/content.txt": "\u003cdiv\u003e\u003cb\u003eBold\u003c/b\u003e\u003c/div\u003e"'
+    assert expected in content
+
+def test_default_behavior_uses_entities(minimal_allure_report):
+    """
+    Verify default behavior uses &lt; and &gt;
+    """
+    html_content = "<div><b>Bold</b></div>"
+    (minimal_allure_report / "data" / "content.txt").write_text(html_content, encoding="utf-8")
+    
+    cmd = _run([sys.executable, "-m", "allure_combine.combine", str(minimal_allure_report)])
+    assert cmd.returncode == 0
+    
+    content = (minimal_allure_report / "complete.html").read_text(encoding="utf-8")
+    
+    # Should use HTML entities
+    expected = '"data/content.txt": "&lt;div&gt;&lt;b&gt;Bold&lt;/b&gt;&lt;/div&gt;"'
+    assert expected in content

--- a/integration_tests/run_dummy_allure.sh
+++ b/integration_tests/run_dummy_allure.sh
@@ -64,5 +64,12 @@ allure-combine "${ignore_src}" --ignore-utf8-errors
 mkdir -p "${VARIANTS_DIR}/ignore-utf8-errors"
 cp "${ignore_src}/complete.html" "${VARIANTS_DIR}/ignore-utf8-errors/complete.html"
 
+# --disable-tags-escaping
+disable_tags_src="$(copy_source_report disable-tags-escaping)"
+allure-combine "${disable_tags_src}" --disable-tags-escaping
+mkdir -p "${VARIANTS_DIR}/disable-tags-escaping"
+cp "${disable_tags_src}/complete.html" "${VARIANTS_DIR}/disable-tags-escaping/complete.html"
+test -f "${VARIANTS_DIR}/disable-tags-escaping/complete.html"
+
 echo "Generated variant HTML reports:"
 find "${VARIANTS_DIR}" -name 'complete.html' -type f | sort

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -15,7 +15,7 @@ else
 fi
 
 mkdir -p "${ARTIFACTS_PATH}"
-rm -rf "${ARTIFACTS_PATH:?}/"*
+docker run --rm -v "${ARTIFACTS_PATH}:/work" alpine sh -c 'rm -rf /work/* || true'
 
 docker build -f integration_tests/Dockerfile -t "${IMAGE_TAG}" .
 docker run --rm \


### PR DESCRIPTION
The replacement of `<` and `>` was breaking some HTML text contents. For example, instead of `<br>` being rendered like an actual line break, it was being rendered as a literal "\<br\>" string.

This PR just removes the replacements. So, if there is a better way to do this, please let me know.